### PR TITLE
Update patch asar for Obsidian 0.8.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,20 @@ const patchAsar = async (asarPath) => {
 
   const indexPath = path.join(asarExtractTemp, 'index.html')
   const indexContent = await fs.promises.readFile(indexPath)
+
+  if (indexContent.toString().indexOf('volcano.js') > -1) {
+    console.log('volcano.js is already loaded')
+    await fs.promises.rmdir(asarExtractTemp, { recursive: true })
+    return
+  }
+
   await fs.promises.writeFile(
     indexPath,
     indexContent
       .toString()
       .replace(
-        '<script type="text/javascript" src="app.js"></script></body>',
-        '<script type="text/javascript" src="app.js"></script><script type="text/javascript" src="volcano.js"></script></body>'
+        /\<script type=\"text\/javascript\" src=\"\/?app\.js\"\>\<\/script\>/,
+        '<script type="text/javascript" src="/app.js"></script><script type="text/javascript" src="volcano.js"></script>'
       )
       .replace(
         `script-src 'self' 'unsafe-inline' blob:; frame-src 'self' https://*:*; style-src 'self' 'unsafe-inline';`,


### PR DESCRIPTION
v0.8.5 of Obsidian uses an absolute path for app.js. It also doesn't have the `script` tag at the very end of the `<body>`.  I switched this to use a regex for the app.js and to early exit of volcano.js is already loaded.